### PR TITLE
Remove COM lines when option off + Brightness/Contrast

### DIFF
--- a/jet_tracking/context.py
+++ b/jet_tracking/context.py
@@ -565,3 +565,10 @@ class Context(object):
         """
         self.find_com_bool = o
         self.signals.comDetection.emit()
+        
+        if not o:
+            self.contours = []
+            self.best_fit_line = []
+            self.best_fit_line_plus = []
+            self.best_fit_line_minus = []
+            self.com = []

--- a/jet_tracking/datastream.py
+++ b/jet_tracking/datastream.py
@@ -1148,12 +1148,12 @@ class JetImageFeed(QObject):
             kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE,
                                                (self.close, self.close))
             im = cv2.morphologyEx(im, cv2.MORPH_CLOSE, kernel)
-        if self.contrast:
-            pass
-        if self.brightness:
-            pass
         if self.blur:
             im = cv2.GaussianBlur(im, (3, 3), self.blur, self.blur)
+        if self.contrast:
+            im = cv2.convertScaleAbs(im, alpha=self.contrast/10)
+        if self.brightness:
+            im = cv2.convertScaleAbs(im, beta=self.brightness)
         ret, im = cv2.threshold(im, self.left_threshold, self.right_threshold,
                                 cv2.THRESH_BINARY)
         return im

--- a/jet_tracking/gui/widgets/editorWidgetUi.py
+++ b/jet_tracking/gui/widgets/editorWidgetUi.py
@@ -77,9 +77,13 @@ class Editor_Ui(object):
 
         obj.lbl_brightness = QLabel("Brightness")
         obj.slider_brightness = QSlider(Qt.Horizontal)
+        obj.slider_brightness.setMinimum(0)
+        obj.slider_brightness.setMaximum(99)
 
         obj.lbl_contrast = QLabel("Contrast")
         obj.slider_contrast = QSlider(Qt.Horizontal)
+        obj.slider_contrast.setMinimum(1)
+        obj.slider_contrast.setMaximum(20)
 
         obj.lbl_blur = QLabel("Blur")
         obj.slider_blur = QSlider(Qt.Horizontal)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Reset lines and contours when the COM detection is off
- Add options for changing Brightness/Contrast in the image

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Remove clutter on image when not needed
- Make detection easier

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on psana

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
